### PR TITLE
Adds support for sub expressions

### DIFF
--- a/addon/components/markdown-to-html.js
+++ b/addon/components/markdown-to-html.js
@@ -26,6 +26,16 @@ export default Ember.Component.extend({
       'tasklists',
       'smoothLivePreview'
     );
+    var markdown = this.get('markdown') || '';
+    var source;
+
+    if (markdown instanceof Ember.Handlebars.SafeString) {
+      source = markdown.toHTML();
+    } else if (Array.isArray(markdown)) {
+      source = markdown[0];
+    } else {
+      source = markdown;
+    }
 
     for (var option in showdownOptions) {
       if (showdownOptions.hasOwnProperty(option)) {
@@ -33,7 +43,6 @@ export default Ember.Component.extend({
       }
     }
 
-    var source = this.get('markdown') || '';
     return new Ember.Handlebars.SafeString(this.converter.makeHtml(source));
   })
 });

--- a/app/helpers/sample.js
+++ b/app/helpers/sample.js
@@ -1,0 +1,1 @@
+export { default, sample } from 'ember-cli-showdown/helpers/sample';

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "ember-qunit": "0.4.9",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.18.0",
     "showdown": "~1.2.3"

--- a/tests/dummy/app/helpers/safestring-sub-expression.js
+++ b/tests/dummy/app/helpers/safestring-sub-expression.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export function sample(params/*, hash*/) {
+  return Ember.String.htmlSafe(params);
+}
+
+export default Ember.Helper.helper(sample);

--- a/tests/dummy/app/helpers/simple-sub-expression.js
+++ b/tests/dummy/app/helpers/simple-sub-expression.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export function sample(params/*, hash*/) {
+  return params;
+}
+
+export default Ember.Helper.helper(sample);

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -3,6 +3,7 @@
 {{textarea value=editableText}}
 {{markdown-to-html markdown=editableText}}
 
-{{markdown-to-html markdown='#Markdown is cool [link](google.com)'}}
+{{markdown-to-html markdown=(safestring-sub-expression '#Converting <em>SafeString</em> sub expressions to Markdown is cool <script>alert("nope")</script>')}}
+{{markdown-to-html markdown=(simple-sub-expression '#Converting simple sub expresions to Markdown is also cool [link](google.com)')}}
 
 {{outlet}}

--- a/tests/unit/components/markdown-to-html-test.js
+++ b/tests/unit/components/markdown-to-html-test.js
@@ -27,6 +27,38 @@ test('it produces markdown', function(assert) {
   assert.equal(component.$().html().toString().trim(), expectedHtml);
 });
 
+test('it produces markdown from a Handlebars sub-expression', function(assert) {
+  assert.expect(2);
+
+  var component = this.subject();
+  this.render();
+
+  Ember.run(function() {
+    component.set('markdown', ['##Hello, [world](#)']);
+  });
+
+  var expectedHtml = '<h2 id="helloworld">Hello, <a href="#">world</a></h2>';
+
+  assert.equal(component.get('html').toString(), expectedHtml);
+  assert.equal(component.$().html().toString().trim(), expectedHtml);
+});
+
+test('it produces markdown from a Handlebars sub-expression that returns a SafeString', function(assert) {
+  assert.expect(2);
+
+  var component = this.subject();
+  this.render();
+
+  Ember.run(function() {
+    component.set('markdown', Ember.String.htmlSafe('##Hello, <em>strange</em>[world](#)'));
+  });
+
+  var expectedHtml = '<h2 id="helloemstrangeemworld">Hello, <em>strange</em><a href="#">world</a></h2>';
+
+  assert.equal(component.get('html').toHTML(), expectedHtml);
+  assert.equal(component.$().html().toString().trim(), expectedHtml);
+});
+
 test('it inserts <br> tag', function(assert) {
   assert.expect(1);
 


### PR DESCRIPTION
This PR adds support for passing in sub-expressions whether they export a basic result or a SafeString result. Allows you to do:

```
{{markdown-to-html markdown=(my-helper someVar)}}
```

Also needed to lock jquery versions in bower.json because was throwing "Assertion Failed: Ember Views require jQuery between 1.7 and 2.1." See https://github.com/emberjs/ember.js/pull/12787 for more info. 
